### PR TITLE
Removing optional redirect param to fix redirect issue

### DIFF
--- a/todo_app/app.py
+++ b/todo_app/app.py
@@ -163,7 +163,6 @@ def create_app():
          token_url, headers, body = client.prepare_token_request(
             "https://github.com/login/oauth/access_token",
             authorization_response=request.url,
-            redirect_url=request.base_url,
             code=code  
          )
 


### PR DESCRIPTION
Please make sure you are raising this PR against your own repository and not the original. If it says https://github.com/CorndelWithSoftwire in the search bar right now, you are in the wrong place!

Please also don't forget to submit the PR's url to Aptem afterwards (by clicking on the corresponding exercise component, pasting the url in the textbox that appears and then pressing the finish button).